### PR TITLE
feat: add sparse checkout support for git uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -995,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,7 +1346,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1658,15 +1677,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -1936,6 +1954,7 @@ dependencies = [
  "secrecy",
  "serde",
  "sha2",
+ "tempfile",
  "tokio",
  "toml",
  "typst-syntax",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,11 @@ octocrab = { version = "0.42.1", features = [
     "rustls",
     "rustls-ring",
 ], default-features = false }
-regex = { version = "1.11.1", default-features = false }
+regex = { version = "1.11.1", features = ["unicode-perl"], default-features = false }
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0.216", features = ["derive"] }
 sha2 = "0.10.8"
+tempfile = "3.20.0"
 tokio = { version = "1.42.0", features = [
     "rt",
     "rt-multi-thread",

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ typship init
 To publish a package, run (then follow the instructions):
 
 ```sh
-typship publish
+typship publish [--upload-method <sparse|api>]
 ```
+
+- `--upload-method sparse` (default): Uses git sparse-checkout to upload your package. Recommended for most users and faster for large packages.
+- `--upload-method api`: Uploads files one by one via GitHub API. Useful for legacy git versions or special needs, but slower.
 
 Download a package to `@local`:
 

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Result;
 use clap::{ArgAction, Parser};
 
-use crate::regs::universe;
+use crate::regs::universe::{self, UploadMethod};
 use crate::utils::read_manifest;
 
 const LONG_ABOUT: &str =
@@ -22,12 +22,21 @@ pub struct PublishArgs {
     #[arg(long_help = "Dry run the publish process. No actual changes will be made.")]
     /// Dry run the publish process
     pub dry_run: bool,
+
+    #[arg(long, value_enum, default_value = "sparse")]
+    #[arg(
+        long_help = "Upload method: sparse (uses git sparse-checkout); api (uploads files one by one, for legacy git, slower)."
+    )]
+    /// Upload method: sparse (uses git sparse-checkout); api (uploads files one by one, for legacy git, slower).
+    pub upload_method: UploadMethod,
 }
 
 pub async fn publish(package_dir: &Path, args: &PublishArgs) -> Result<()> {
     let current = read_manifest(package_dir)?;
     match args.registry.as_str() {
-        "universe" => universe::publish(&current, package_dir, args.dry_run).await?,
+        "universe" => {
+            universe::publish(&current, package_dir, args.dry_run, args.upload_method).await?
+        }
         _ => {
             anyhow::bail!("Unsupported registry: {}", args.registry);
         }

--- a/src/regs/universe.rs
+++ b/src/regs/universe.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::sync::{LazyLock, OnceLock};
 
 use anyhow::{anyhow, bail, Result};
+use clap::ValueEnum;
 use crossterm::style::Stylize;
 use dialoguer::{Confirm, Input};
 use futures_util::TryStreamExt;
@@ -112,7 +113,18 @@ Enter your GitHub personal access token
     Ok(())
 }
 
-pub async fn publish(manifest: &PackageManifest, package_dir: &Path, dry_run: bool) -> Result<()> {
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum UploadMethod {
+    Sparse,
+    Api,
+}
+
+pub async fn publish(
+    manifest: &PackageManifest,
+    package_dir: &Path,
+    dry_run: bool,
+    upload_method: UploadMethod,
+) -> Result<()> {
     // TODO: check if exist in package repo(name), check pr
     info!("Checking the packages in the official packages repo...");
     let mut is_new_package = true;
@@ -294,27 +306,43 @@ pub async fn publish(manifest: &PackageManifest, package_dir: &Path, dry_run: bo
             bail!("Aborted");
         }
 
-        // Check git version and choose upload method
-        let use_sparse_checkout = check_git_version().unwrap_or(false);
-        
-        if use_sparse_checkout {
-            upload_files_sparse_checkout(
-                client,
-                &me.login,
-                &my_repo,
-                &submission,
-                package_dir,
-                &files,
-            ).await?;
-        } else {
-            upload_files_api(
-                client,
-                &me.login,
-                &my_repo,
-                &submission,
-                package_dir,
-                &files,
-            ).await?;
+        match upload_method {
+            UploadMethod::Sparse => {
+                let use_sparse_checkout = check_git_version().unwrap_or(false);
+                if use_sparse_checkout {
+                    upload_files_sparse_checkout(
+                        client,
+                        &me.login,
+                        &my_repo,
+                        &submission,
+                        package_dir,
+                        &files,
+                    )
+                    .await?;
+                } else {
+                    info!("Git version does not support sparse-checkout, automatically switch to api upload method.");
+                    upload_files_api(
+                        client,
+                        &me.login,
+                        &my_repo,
+                        &submission,
+                        package_dir,
+                        &files,
+                    )
+                    .await?;
+                }
+            }
+            UploadMethod::Api => {
+                upload_files_api(
+                    client,
+                    &me.login,
+                    &my_repo,
+                    &submission,
+                    package_dir,
+                    &files,
+                )
+                .await?;
+            }
         }
     } else {
         info!("Dry run: file upload skipped");
@@ -421,21 +449,19 @@ impl SubmissionMessage {
 }
 
 fn check_git_version() -> Result<bool> {
-    let output = Command::new("git")
-        .args(["--version"])
-        .output()?;
-    
+    let output = Command::new("git").args(["--version"]).output()?;
+
     if !output.status.success() {
         bail!("Failed to check git version");
     }
-    
+
     let version_str = String::from_utf8_lossy(&output.stdout);
     let version_regex = Regex::new(r"git version (\d+)\.(\d+)\.(\d+).*")?;
-    
+
     if let Some(captures) = version_regex.captures(&version_str) {
         let major: u32 = captures[1].parse()?;
         let minor: u32 = captures[2].parse()?;
-        
+
         // sparse-checkout --cone requires Git 2.25+
         Ok(major > 2 || (major == 2 && minor >= 25))
     } else {
@@ -482,115 +508,140 @@ async fn upload_files_sparse_checkout(
     files: &[PathBuf],
 ) -> Result<()> {
     let typst_toml_content = std::fs::read(package_dir.join("typst.toml"))?;
-    
+
     client
         .repos(user_login, repo_name)
         .create_file(
-            submission.repo_path().join("typst.toml").to_string_lossy().into_owned(),
+            submission
+                .repo_path()
+                .join("typst.toml")
+                .to_string_lossy()
+                .into_owned(),
             "[Typship] Initialize package version directory".to_string(),
             &typst_toml_content,
         )
         .branch(submission.branch_name())
         .send()
         .await?;
-    
-    
+
     let temp_dir = TempDir::new()?;
     let temp_path = temp_dir.path();
-    
+
     let fork_url = format!("https://github.com/{}/{}.git", user_login, repo_name);
     let target_path = submission.repo_path();
-    
+
     let output = Command::new("git")
         .args([
             "clone",
             "--filter=blob:none",
             "--no-checkout",
             "--single-branch",
-            "--branch", &submission.branch_name(),
+            "--branch",
+            &submission.branch_name(),
             &fork_url,
-            "repo"
+            "repo",
         ])
         .current_dir(temp_path)
         .output()?;
-    
+
     if !output.status.success() {
-        bail!("Failed to clone repository: {}", String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to clone repository: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    
+
     let repo_path = temp_path.join("repo");
-    
+
     let output = Command::new("git")
         .args(["sparse-checkout", "init", "--cone"])
         .current_dir(&repo_path)
         .output()?;
-    
+
     if !output.status.success() {
-        bail!("Failed to initialize sparse-checkout: {}", String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to initialize sparse-checkout: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    
+
     let output = Command::new("git")
         .args(["sparse-checkout", "set", &target_path.to_string_lossy()])
         .current_dir(&repo_path)
         .output()?;
-    
+
     if !output.status.success() {
-        bail!("Failed to set sparse-checkout patterns: {}", String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to set sparse-checkout patterns: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    
+
     let output = Command::new("git")
         .args(["checkout"])
         .current_dir(&repo_path)
         .output()?;
-    
+
     if !output.status.success() {
-        bail!("Failed to checkout files: {}", String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to checkout files: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    
+
     let local_target_dir = repo_path.join(&target_path);
     std::fs::create_dir_all(&local_target_dir)?;
-    
+
     for file in files {
         let src_path = package_dir.join(file);
         let dst_path = local_target_dir.join(file);
-        
+
         if let Some(parent) = dst_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        
+
         std::fs::copy(&src_path, &dst_path)?;
     }
-    
+
     let output = Command::new("git")
         .args(["add", "."])
         .current_dir(&repo_path)
         .output()?;
-    
+
     if !output.status.success() {
-        bail!("Failed to add files to git: {}", String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to add files to git: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    
-    let commit_message = format!("[Typship] Add package {}:{}", submission.name, submission.version);
+
+    let commit_message = format!(
+        "[Typship] Add package {}:{}",
+        submission.name, submission.version
+    );
     let output = Command::new("git")
         .args(["commit", "-m", &commit_message])
         .current_dir(&repo_path)
         .output()?;
-    
+
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         if !stderr.contains("nothing to commit") {
             bail!("Failed to commit files: {}", stderr);
         }
     }
-    
+
     let output = Command::new("git")
         .args(["push", "origin", &submission.branch_name()])
         .current_dir(&repo_path)
         .output()?;
-    
+
     if !output.status.success() {
-        bail!("Failed to push to remote: {}", String::from_utf8_lossy(&output.stderr));
+        bail!(
+            "Failed to push to remote: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    
+
     Ok(())
 }

--- a/src/regs/universe.rs
+++ b/src/regs/universe.rs
@@ -11,7 +11,10 @@ use log::{info, warn};
 use octocrab::models::pulls::PullRequest;
 use octocrab::models::repos::{ContentItems, Object};
 use octocrab::{params, Octocrab, Page};
+use regex::Regex;
 use secrecy::SecretString;
+use std::process::Command;
+use tempfile::TempDir;
 use typst_syntax::package::{PackageManifest, PackageVersion};
 
 use crate::config::CONFIG;
@@ -196,7 +199,7 @@ pub async fn publish(manifest: &PackageManifest, package_dir: &Path, dry_run: bo
         .allow_empty(false)
         .default(UNIVERSE_REPO_NAME.into())
         .interact_text()?;
-    let my_fork = client.repos(&me.login, my_repo);
+    let my_fork = client.repos(&me.login, &my_repo);
     let parent = my_fork.get().await?.parent;
     if let Some(p) = parent {
         if p.name != UNIVERSE_REPO_NAME
@@ -291,23 +294,27 @@ pub async fn publish(manifest: &PackageManifest, package_dir: &Path, dry_run: bo
             bail!("Aborted");
         }
 
-        // TODO: multi-threading?
-        for file in files {
-            let content = std::fs::read(package_dir.join(&file))?;
-            my_fork
-                .create_file(
-                    submission
-                        .repo_path()
-                        .join(&file)
-                        .to_string_lossy()
-                        .into_owned(),
-                    format!("[Typship] Add {}", file.display()),
-                    &content,
-                )
-                .branch(submission.branch_name())
-                .send()
-                .await
-                .map(|_| info!("Uploaded: {}", file.display()))?;
+        // Check git version and choose upload method
+        let use_sparse_checkout = check_git_version().unwrap_or(false);
+        
+        if use_sparse_checkout {
+            upload_files_sparse_checkout(
+                client,
+                &me.login,
+                &my_repo,
+                &submission,
+                package_dir,
+                &files,
+            ).await?;
+        } else {
+            upload_files_api(
+                client,
+                &me.login,
+                &my_repo,
+                &submission,
+                package_dir,
+                &files,
+            ).await?;
         }
     } else {
         info!("Dry run: file upload skipped");
@@ -411,4 +418,179 @@ impl SubmissionMessage {
             if has_template { template } else { "" }
         )
     }
+}
+
+fn check_git_version() -> Result<bool> {
+    let output = Command::new("git")
+        .args(["--version"])
+        .output()?;
+    
+    if !output.status.success() {
+        bail!("Failed to check git version");
+    }
+    
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    let version_regex = Regex::new(r"git version (\d+)\.(\d+)\.(\d+).*")?;
+    
+    if let Some(captures) = version_regex.captures(&version_str) {
+        let major: u32 = captures[1].parse()?;
+        let minor: u32 = captures[2].parse()?;
+        
+        // sparse-checkout --cone requires Git 2.25+
+        Ok(major > 2 || (major == 2 && minor >= 25))
+    } else {
+        warn!("Could not parse git version, falling back to API upload");
+        Ok(false)
+    }
+}
+
+async fn upload_files_api(
+    client: &Octocrab,
+    user_login: &str,
+    repo_name: &str,
+    submission: &PackageSubmission,
+    package_dir: &Path,
+    files: &[PathBuf],
+) -> Result<()> {
+    for file in files {
+        let content = std::fs::read(package_dir.join(file))?;
+        client
+            .repos(user_login, repo_name)
+            .create_file(
+                submission
+                    .repo_path()
+                    .join(file)
+                    .to_string_lossy()
+                    .into_owned(),
+                format!("[Typship] Add {}", file.display()),
+                &content,
+            )
+            .branch(submission.branch_name())
+            .send()
+            .await
+            .map(|_| info!("Uploaded: {}", file.display()))?;
+    }
+    Ok(())
+}
+
+async fn upload_files_sparse_checkout(
+    client: &Octocrab,
+    user_login: &str,
+    repo_name: &str,
+    submission: &PackageSubmission,
+    package_dir: &Path,
+    files: &[PathBuf],
+) -> Result<()> {
+    let typst_toml_content = std::fs::read(package_dir.join("typst.toml"))?;
+    
+    client
+        .repos(user_login, repo_name)
+        .create_file(
+            submission.repo_path().join("typst.toml").to_string_lossy().into_owned(),
+            "[Typship] Initialize package version directory".to_string(),
+            &typst_toml_content,
+        )
+        .branch(submission.branch_name())
+        .send()
+        .await?;
+    
+    
+    let temp_dir = TempDir::new()?;
+    let temp_path = temp_dir.path();
+    
+    let fork_url = format!("https://github.com/{}/{}.git", user_login, repo_name);
+    let target_path = submission.repo_path();
+    
+    let output = Command::new("git")
+        .args([
+            "clone",
+            "--filter=blob:none",
+            "--no-checkout",
+            "--single-branch",
+            "--branch", &submission.branch_name(),
+            &fork_url,
+            "repo"
+        ])
+        .current_dir(temp_path)
+        .output()?;
+    
+    if !output.status.success() {
+        bail!("Failed to clone repository: {}", String::from_utf8_lossy(&output.stderr));
+    }
+    
+    let repo_path = temp_path.join("repo");
+    
+    let output = Command::new("git")
+        .args(["sparse-checkout", "init", "--cone"])
+        .current_dir(&repo_path)
+        .output()?;
+    
+    if !output.status.success() {
+        bail!("Failed to initialize sparse-checkout: {}", String::from_utf8_lossy(&output.stderr));
+    }
+    
+    let output = Command::new("git")
+        .args(["sparse-checkout", "set", &target_path.to_string_lossy()])
+        .current_dir(&repo_path)
+        .output()?;
+    
+    if !output.status.success() {
+        bail!("Failed to set sparse-checkout patterns: {}", String::from_utf8_lossy(&output.stderr));
+    }
+    
+    let output = Command::new("git")
+        .args(["checkout"])
+        .current_dir(&repo_path)
+        .output()?;
+    
+    if !output.status.success() {
+        bail!("Failed to checkout files: {}", String::from_utf8_lossy(&output.stderr));
+    }
+    
+    let local_target_dir = repo_path.join(&target_path);
+    std::fs::create_dir_all(&local_target_dir)?;
+    
+    for file in files {
+        let src_path = package_dir.join(file);
+        let dst_path = local_target_dir.join(file);
+        
+        if let Some(parent) = dst_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        
+        std::fs::copy(&src_path, &dst_path)?;
+    }
+    
+    let output = Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_path)
+        .output()?;
+    
+    if !output.status.success() {
+        bail!("Failed to add files to git: {}", String::from_utf8_lossy(&output.stderr));
+    }
+    
+    let commit_message = format!("[Typship] Add package {}:{}", submission.name, submission.version);
+    let output = Command::new("git")
+        .args(["commit", "-m", &commit_message])
+        .current_dir(&repo_path)
+        .output()?;
+    
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.contains("nothing to commit") {
+            bail!("Failed to commit files: {}", stderr);
+        }
+    }
+    
+    let output = Command::new("git")
+        .args(["push", "origin", &submission.branch_name()])
+        .current_dir(&repo_path)
+        .output()?;
+    
+    if !output.status.success() {
+        bail!("Failed to push to remote: {}", String::from_utf8_lossy(&output.stderr));
+    }
+    
+    Ok(())
 }


### PR DESCRIPTION
- Implement sparse-checkout upload method for faster package publishing (First upload the `typst.toml` for creating corresponding dir, then `sparse-checkout` and `push` them together)
- Notice that `sparse-checkout` only supports Git >= 2.25. So for those who have Git < 2.25 installed, Typship falls back to api upload method